### PR TITLE
Standardize heading capitalization to sentence case

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -136,7 +136,7 @@
                     </svg>
                   </div>
                   <h2 class="font-sans font-bold text-3xl sm:text-4xl lg:text-5xl">
-                    One View for Both of You
+                    One view for both of you
                   </h2>
                 </div>
                 <p class="text-xl text-blue-really-light leading-relaxed">
@@ -174,7 +174,7 @@
                     </svg>
                   </div>
                   <h2 class="font-sans font-bold text-3xl sm:text-4xl lg:text-5xl">
-                    Stay Fair, Stay Aligned
+                    Stay fair, stay aligned
                   </h2>
                 </div>
                 <p class="text-xl text-blue-really-light leading-relaxed">
@@ -212,7 +212,7 @@
                     </svg>
                   </div>
                   <h2 class="font-sans font-bold text-3xl sm:text-4xl lg:text-5xl">
-                    Budget Together, Succeed Together
+                    Budget together, succeed together
                   </h2>
                 </div>
                 <p class="text-xl text-blue-really-light leading-relaxed">
@@ -250,7 +250,7 @@
                     </svg>
                   </div>
                   <h2 class="font-sans font-bold text-3xl sm:text-4xl lg:text-5xl">
-                    Save for Your Dreams Together
+                    Save for your dreams together
                   </h2>
                 </div>
                 <div class="mb-4">


### PR DESCRIPTION
Update headings to use sentence case, excluding 'Sloth Money', as per user request.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c30578b-887b-4280-9bff-49cd5a5e146b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c30578b-887b-4280-9bff-49cd5a5e146b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

