### PR TITLE
Adjust tagline casing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sloth-money-landing",
   "version": "1.0.0",
-  "description": "Sloth Money - The Budgeting App Built for Two",
+  "description": "Sloth Money - The budgeting app built for two",
   "scripts": {
     "dev:css": "tailwindcss -i ./src/assets/css/tailwind.css -o ./src/output.css --watch",
     "dev:server": "browser-sync start --server src --index index.html --port 3000 --files 'src/**/*' --no-notify",

--- a/src/index.html
+++ b/src/index.html
@@ -3,14 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sloth Money — The Budgeting App Built for Two</title>
+    <title>Sloth Money — The budgeting app built for two</title>
     
     <!-- SEO Meta Tags -->
     <meta name="description" content="Manage money together without the stress. Track shared spending, set goals, and celebrate milestones — all in one simple app for couples." />
     <meta name="keywords" content="couples budgeting, shared finances, budgeting app, financial planning for couples" />
     
     <!-- Open Graph Meta Tags -->
-    <meta property="og:title" content="Sloth Money — The Budgeting App Built for Two" />
+    <meta property="og:title" content="Sloth Money — The budgeting app built for two" />
     <meta property="og:description" content="Manage money together without the stress. Track shared spending, set goals, and celebrate milestones — all in one simple app for couples." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://slothmoney.app/" />
@@ -18,7 +18,7 @@
     
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="Sloth Money — The Budgeting App Built for Two" />
+    <meta name="twitter:title" content="Sloth Money — The budgeting app built for two" />
     <meta name="twitter:description" content="Manage money together without the stress. Track shared spending, set goals, and celebrate milestones — all in one simple app for couples." />
     <meta name="twitter:image" content="/assets/images/sloth_money_logo_white.png" />
     
@@ -75,8 +75,8 @@
             <!-- Main headline -->
             <h1 class="font-sans font-bold text-4xl sm:text-5xl lg:text-7xl leading-none mb-8 space-y-2">
               <span class="block">Sloth Money</span>
-              <span class="block text-green-light">The Budgeting App</span>
-              <span class="block">Built for Two</span>
+              <span class="block text-green-light">The budgeting app</span>
+              <span class="block">built for two</span>
             </h1>
             
             <!-- Subheading -->


### PR DESCRIPTION
## Summary
- update hero headline to use sentence case tagline
- align SEO and social metadata along with package description to the new casing

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca54ae6e408327b194d26f7f104571