### PR TITLE
Move footer year script to external file

### DIFF
--- a/src/assets/js/footer-year.js
+++ b/src/assets/js/footer-year.js
@@ -1,0 +1,5 @@
+const footerYearElement = document.getElementById('footer-year');
+
+if (footerYearElement) {
+  footerYearElement.textContent = new Date().getFullYear();
+}

--- a/src/index.html
+++ b/src/index.html
@@ -423,10 +423,13 @@
           </div>
           
           <div class="text-center text-sm text-gray-500">
-            <p>&copy; 2024 Sloth Money. All rights reserved.</p>
+            <p>
+              &copy; <span id="footer-year"></span> Sloth Money. All rights reserved.
+            </p>
           </div>
         </div>
       </div>
     </footer>
+    <script src="assets/js/footer-year.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a dedicated footer-year script that updates the copyright date
- reference the external script from the footer instead of using inline JavaScript

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cc158ab8bc832798aea0c916b4aa22