### PR TITLE
Patch ws memory exhaustion vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "resolutions": {
     "glob": "10.5.0",
     "qs": "6.15.2",
-    "shell-quote": "1.8.4"
+    "shell-quote": "1.8.4",
+    "ws": "8.21.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1756,10 +1756,10 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
-ws@~8.18.3:
-  version "8.18.3"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
-  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+ws@8.21.0, ws@~8.18.3:
+  version "8.21.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.0.tgz#012e413fc07429945121b0c153158c4343086951"
+  integrity sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==
 
 xmlhttprequest-ssl@~2.1.1:
   version "2.1.2"


### PR DESCRIPTION
## What changed

- add a targeted Yarn resolution for `ws@8.21.0`
- refresh the single `ws` entry in `yarn.lock`

## Why

Dependabot alert #62 (`GHSA-96hv-2xvq-fx4p`) reports a high-severity memory exhaustion denial of service in `ws < 8.21.0`. The affected package is a transitive development dependency reached through BrowserSync's Socket.IO/Engine.IO stack.

Engine.IO, Engine.IO Client, and Socket.IO Adapter request `ws@~8.18.3`, so the patched minor is outside their declared range. The targeted resolution is permitted because it stays on major 8 and the compatibility checks passed.

## Compatibility assessment

- `ws@8.21.0` retains the same Node requirement (`>=10`) and optional peer dependencies as `8.18.3`
- Engine.IO uses the preserved public `WebSocket`, `WebSocket.Server`, and `handleUpgrade` APIs
- Socket.IO Adapter's `WebSocket.Sender.frame` integration remains exported with the same signature
- upstream changes are security fixes, receiver/sender hardening, and additive options/exports
- npm registry metadata has no deprecation or warning for `8.21.0`

## Validation

- `yarn install --frozen-lockfile`
- `yarn lint`
- `yarn typecheck`
- `yarn build`
- BrowserSync served `http://127.0.0.1:3100/?ws-smoke=1720787001` with HTTP 200
- system Chrome established `ws://127.0.0.1:3100/browser-sync/socket.io/...` and reported no page errors
- `git diff --check`

## Impact

Dependency metadata only. No source, build configuration, generated output, package-manager, logging, or tracking changes.